### PR TITLE
Fix DEPENDS-ON? for GE-TIMES and GE-PLUS.

### DIFF
--- a/general.lisp
+++ b/general.lisp
@@ -893,10 +893,10 @@ arrays."))
       (apply #'depends-on? (args-of exp) vars)))		     
 
 (defmethod depends-on? ((exp ge-plus) &rest vars)
-  (depends-on? (terms-of exp) vars))
+  (apply #'depends-on? (terms-of exp) vars))
 
 (defmethod depends-on? ((exp ge-times) &rest vars)
-  (depends-on? (terms-of exp) vars))
+  (apply #'depends-on? (terms-of exp) vars))
 
 (defmethod depends-on? ((exp ge-expt) &rest vars)
   (or (apply #'depends-on? (base-of exp) vars)


### PR DESCRIPTION
DEPENDS-ON? should be APPLY'ed in these specializations so that VARS is
not wrapped in another list.
